### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:15.04
+# From here we load our application's code in, therefore the previous docker
+# "layer" thats been cached will be used if possible
+run apt-get install -yq wget
+RUN wget https://apt.puppetlabs.com/puppetlabs-release-trusty.deb
+RUN dpkg -i puppetlabs-release-trusty.deb
+RUN apt-get update -yq && apt-get upgrade -yq && DEBIAN_FRONTEND=noninteractive apt-get install -yq curl git vim puppetmaster
+ADD ./ /etc/puppet
+WORKDIR /etc/puppet/


### PR DESCRIPTION
Verified that it builds, adds the WORKDIR correctly, and the resulting
image can be made into a container that runs and a puppet master can be
started inside without errors. (several warnings though).
Puppet 3.8.1 inside the container.
